### PR TITLE
Publish 1 tf2 message per frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ install(FILES
   src/simple.py
   src/tf2_test.py
   src/usb_camera.py
+  src/util.py
   DESTINATION lib/flock2
 )
 

--- a/msg/FlightData.msg
+++ b/msg/FlightData.msg
@@ -4,7 +4,8 @@
 # Battery state:
 int32 battery_percent                     # Remaining battery, 0-100
 float32 estimated_flight_time_remaining   # Remaining flight time, seconds
-bool low_battery                          # Battery is low
+bool battery_low                          # Battery is low
+bool battery_lower                        # Battery is really low (the red light is flashing)
 
 # Flight modes:
 uint8 FLIGHT_MODE_GROUND=1          # Motors off

--- a/src/flock_driver.py
+++ b/src/flock_driver.py
@@ -98,7 +98,8 @@ class FlockDriver(Node):
         # Battery state
         flight_data.battery_percent = data.battery_percentage
         flight_data.estimated_flight_time_remaining = data.drone_fly_time_left / 10.
-        flight_data.low_battery = bool(data.battery_low)
+        flight_data.battery_low = bool(data.battery_low)
+        flight_data.battery_lower = bool(data.battery_lower)
 
         # Flight mode
         flight_data.flight_mode = data.fly_mode
@@ -128,8 +129,6 @@ class FlockDriver(Node):
 
         # Debugging: is there data here? Print nonzero values
         log = self.get_logger()
-        if data.battery_lower:
-            log.info('battery_lower is nonzero: %d' % data.battery_lower)
         if data.battery_state:
             log.info('battery_state is nonzero: %d' % data.battery_state)
         if data.drone_battery_left:

--- a/src/usb_camera.py
+++ b/src/usb_camera.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
 import threading
-import time
 
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, QoSDurabilityPolicy, QoSHistoryPolicy, QoSReliabilityPolicy
-from builtin_interfaces.msg import Time
-from geometry_msgs.msg import Transform, TransformStamped, Vector3
+from geometry_msgs.msg import Vector3
 from sensor_msgs.msg import Image
 from std_msgs.msg import ColorRGBA
 from tf2_msgs.msg import TFMessage
@@ -17,16 +15,10 @@ from cv_bridge import CvBridge
 import cv2
 import numpy
 
+import util
 import detect_aruco
 
-# Grab frames from a USB camera and publish them as ROS messages at 1Hz for testing
-
-
-def now():
-    cpu_time = time.time()
-    sec = int(cpu_time)
-    nanosec = int((cpu_time - sec) * 1000000)
-    return Time(sec=sec, nanosec=nanosec)
+# Grab frames from a USB camera for testing
 
 
 class CameraTest(Node):
@@ -69,17 +61,6 @@ class CameraTest(Node):
         self._video_thread = None
         self._stop_request = None
 
-    def publish_tf(self, pose, stamp, child_frame):
-        v = Vector3(x=pose.position.x, y=pose.position.y, z=pose.position.z)
-        geometry_msg = TransformStamped()
-        geometry_msg.header.frame_id = 'odom'
-        geometry_msg.header.stamp = stamp
-        geometry_msg.child_frame_id = child_frame
-        geometry_msg.transform = Transform(translation=v, rotation=pose.orientation)
-        tf2_msg = TFMessage()
-        tf2_msg.transforms.append(geometry_msg)
-        self._tf_pub.publish(tf2_msg)
-
     def start(self):
         self.get_logger().info("starting video thread")
         self._stop_request = threading.Event()
@@ -97,7 +78,7 @@ class CameraTest(Node):
         cap = cv2.VideoCapture(0)
 
         while not self._stop_request.isSet():
-            stamp = now()
+            stamp = util.now()
             ret, frame = cap.read()
             if not ret:
                 continue
@@ -116,7 +97,8 @@ class CameraTest(Node):
 
             # Publish transforms and rviz markers
             if drone_pose is not None and marker_poses is not None:
-                self.publish_tf(drone_pose, stamp, child_frame='base_link')
+                tf2 = TFMessage()
+                tf2.transforms.append(util.pose_to_transform(drone_pose, stamp, 'odom', 'base_link'))
                 marker_array = MarkerArray()
                 for marker_id, marker_pose in marker_poses.items():
                     marker = Marker()
@@ -128,7 +110,8 @@ class CameraTest(Node):
                     marker.scale = Vector3(x=0.1, y=0.1, z=0.01)
                     marker.color = ColorRGBA(r=1., g=1., b=0., a=1.)
                     marker_array.markers.append(marker)
-                    self.publish_tf(marker_pose, stamp, 'marker%d' % marker_id)
+                    tf2.transforms.append(util.pose_to_transform(marker_pose, stamp, 'odom', 'marker%d' % marker_id))
+                self._tf_pub.publish(tf2)
                 self._rviz_markers_pub.publish(marker_array)
 
         cap.release()

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,21 @@
+import time
+
+from builtin_interfaces.msg import Time
+from geometry_msgs.msg import Transform, TransformStamped, Vector3
+
+
+def now():
+    cpu_time = time.time()
+    sec = int(cpu_time)
+    nanosec = int((cpu_time - sec) * 1000000)
+    return Time(sec=sec, nanosec=nanosec)
+
+
+def pose_to_transform(pose, stamp, parent_frame, child_frame):
+    v = Vector3(x=pose.position.x, y=pose.position.y, z=pose.position.z)
+    transform_stamped = TransformStamped()
+    transform_stamped.header.stamp = stamp
+    transform_stamped.header.frame_id = parent_frame
+    transform_stamped.child_frame_id = child_frame
+    transform_stamped.transform = Transform(translation=v, rotation=pose.orientation)
+    return transform_stamped


### PR DESCRIPTION
Publish 1 tf2 message per frame, so 30Hz overall.

The tf display in rviz2 seems to lag the marker display. However, from the command line the tf messages seem to responding quickly to changes:

`ros2 run tf2_ros tf2_echo odom marker0`

I moved some common functions into util.py. Rebuild required.

I also added 'battery_lower' to the FlightData.msg. This appears when the red light is flashing.